### PR TITLE
Update Gradle to 8.8

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -90,20 +90,26 @@ jobs:
 
   build-checks:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        jvm: [8, 11, 17]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
         distribution: zulu
-        java-version: 8
+        java-version: ${{ matrix.jvm }}
     - run: ./gradlew -DallVersions build -x test -x javadoc -x integrationTest
 
   build-javadoc:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        jvm: [8, 11, 17]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
         distribution: zulu
-        java-version: 8
+        java-version: ${{ matrix.jvm }}
     - run: ./gradlew -Pquick=true javadoc

--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,9 @@ subprojects {
     }
 
     tasks.configureEach { rootTask ->
+      if (rootTask.name == 'revapiAnalyze') {
+        rootTask.dependsOn ':iceberg-common:jar'
+      }
       if (rootTask.name == 'revapi') {
         rootTask.finalizedBy showDeprecationRulesOnRevApiFailure
       }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 # checksum was taken from https://gradle.org/release-checksums
-distributionSha256Sum=e111cb9948407e26351227dabce49822fb88c37ee72f1d1582a69c68af2e702f
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionSha256Sum=a4b4158601f8636cdeeab09bd76afb640030bb5b144aafe261a5e8af027dc612
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This is in preparation for supporting builds on JDK 21.
Gradle 8.1.1 does not support running on JDK 21. At least 8.5 is needed.