### PR TITLE
Run Flink and Spark3 tests on Java 17 too

### DIFF
--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        jvm: [8, 11]
+        jvm: [8, 11, 17]
         flink: ['1.17', '1.18', '1.19']
     env:
       SPARK_LOCAL_IP: localhost

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        jvm: [8, 11]
+        jvm: [8, 11, 17]
         spark: ['3.3', '3.4', '3.5']
     env:
       SPARK_LOCAL_IP: localhost
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        jvm: [8, 11]
+        jvm: [8, 11, 17]
         spark: ['3.3','3.4','3.5']
     env:
       SPARK_LOCAL_IP: localhost


### PR DESCRIPTION
Project supports building with 8, 11 and 17. In most CI scripts we run the jobs on all supported Java versions, let's do same here to ensure the build would work locally too.